### PR TITLE
Use the native libuuid on macOS

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -10,16 +10,12 @@ cxx_compiler_version:
 - '11'
 libcurl:
 - '7'
-libuuid:
-- 2.32.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - 1.1.1
 pin_run_as_build:
   libcurl:
-    max_pin: x
-  libuuid:
     max_pin: x
   openssl:
     max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bc578434b9bfa524a20952f4f60e4135dfcfc10749044e7abc6c62503e14ed6f
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("scitokens-cpp", max_pin="x") }}
   skip: true  # [win]
@@ -26,7 +26,7 @@ requirements:
     - gtest
     - jwt-cpp 0.4.*
     - libcurl
-    - libuuid
+    - libuuid  # [linux]
     - openssl
     - picojson
     - sqlite


### PR DESCRIPTION
This PR modifies the build to use the native version of `libuuid` included with macOS. Apparently the native version is incompatible with the conda-forge version to the point where I can't build htcondor if the conda-forge version is present (because other parts of macOS get in the way).

Hopefully this is non-invasive.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
