### PR TITLE
Vendor jwt-cpp instead of using external

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,13 @@ source:
   patches:
     # https://github.com/scitokens/scitokens-cpp/issues/70
     - macos-uuid.patch  # [osx]
+    # https://github.com/scitokens/scitokens-cpp/issues/61
+    - vendor-jwt-cpp.patch
 
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("scitokens-cpp", max_pin="x") }}
   skip: true  # [win]
@@ -29,7 +31,7 @@ requirements:
     - pkg-config
   host:
     - gtest
-    - jwt-cpp 0.4.*
+    #- jwt-cpp 0.4.*  <-- jwt-cpp 0.4.0 isn't being migrated on conda-forge
     - libcurl
     - libuuid  # [linux]
     - openssl
@@ -46,7 +48,9 @@ about:
   dev_url: https://github.com/scitokens/scitokens-cpp
   summary: A C++ implementation of the SciTokens library with a C library interface
   license: Apache-2.0
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - vendor/jwt-cpp/LICENSE
   description: |
     SciTokens provide a token format for distributed authorization.
     The tokens are self-describing, can be verified in a distributed

--- a/recipe/vendor-jwt-cpp.patch
+++ b/recipe/vendor-jwt-cpp.patch
@@ -1,0 +1,10 @@
+diff --git a/cmake/Findjwt-cpp.cmake b/cmake/Findjwt-cpp.cmake
+index a8272f7..2346ba0 100644
+--- a/cmake/Findjwt-cpp.cmake
++++ b/cmake/Findjwt-cpp.cmake
+@@ -6,4 +6,5 @@ FIND_PATH(JWT_CPP_INCLUDES jwt-cpp/jwt.h
+   /usr
+   ${PROJECT_SOURCE_DIR}/vendor/jwt-cpp
+   PATH_SUFFIXES include
++  NO_CMAKE_FIND_ROOT_PATH
+ )


### PR DESCRIPTION
This PR rebuilds this version using the vendored copy of jwt-cpp, since the pin for that package is to an old version that isn't being migrated.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
